### PR TITLE
Make dpservice-cli more like kubectl

### DIFF
--- a/cmd/command.go
+++ b/cmd/command.go
@@ -13,7 +13,7 @@ func Command() *cobra.Command {
 	rendererOptions := &RendererOptions{}
 
 	cmd := &cobra.Command{
-		Use:           "dpservice-cli",
+		Use:           "dpservice-cli [command]",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -260,14 +260,14 @@ func ParsePrefixArgs(args []string) ([]netip.Prefix, error) {
 }
 
 var (
-	InterfaceAliases          = []string{"interfaces", "iface", "ifaces"}
-	PrefixAliases             = []string{"prefixes", "prfx", "prfxs"}
-	RouteAliases              = []string{"routes", "rt", "rts"}
-	VirtualIPAliases          = []string{"virtualips", "vip", "vips"}
-	LoadBalancerAliases       = []string{"loadbalancers", "loadbalancer", "lbs", "lb"}
-	LoadBalancerPrefixAliases = []string{"loadbalancer-prefixes", "lbprfx", "lbprfxs"}
-	LoadBalancerTargetAliases = []string{"loadbalancer-targets", "lbtrgt", "lbtrgts", "lbtarget"}
-	NatAliases                = []string{"translation"}
+	InterfaceAliases          = []string{"interface", "interfaces", "iface", "ifaces"}
+	PrefixAliases             = []string{"prefix", "prefixes", "prfx", "prfxs"}
+	RouteAliases              = []string{"route", "routes", "rt", "rts"}
+	VirtualIPAliases          = []string{"virtualip", "virtualips", "vip", "vips"}
+	LoadBalancerAliases       = []string{"loadbalancer", "loadbalancers", "loadbalancer", "lbs", "lb"}
+	LoadBalancerPrefixAliases = []string{"loadbalancer-prefix", "loadbalancer-prefixes", "lbprefix", "lbprfx", "lbprfxs"}
+	LoadBalancerTargetAliases = []string{"loadbalancer-target", "loadbalancer-targets", "lbtrgt", "lbtrgts", "lbtarget"}
+	NatAliases                = []string{"nat", "translation"}
 	NeighborNatAliases        = []string{"nnat", "ngbnat", "neighnat"}
-	FirewallRuleAliases       = []string{"fwrule", "fw-rule", "firewallrules", "fwrules", "fw-rules"}
+	FirewallRuleAliases       = []string{"firewallrule", "fwrule", "fw-rule", "firewallrules", "fwrules", "fw-rules"}
 )

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -22,7 +22,7 @@ func Create(factory DPDKClientFactory) *cobra.Command {
 	sourcesOptions := &SourcesOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "create",
+		Use:     "create [command]",
 		Aliases: []string{"add"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -22,7 +22,7 @@ func Delete(factory DPDKClientFactory) *cobra.Command {
 	rendererOptions := &RendererOptions{Output: "name"}
 
 	cmd := &cobra.Command{
-		Use:     "delete",
+		Use:     "delete [command]",
 		Aliases: []string{"del"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -13,7 +13,7 @@ func Get(factory DPDKClientFactory) *cobra.Command {
 	rendererOptions := &RendererOptions{Output: "table"}
 
 	cmd := &cobra.Command{
-		Use:  "get",
+		Use:  "get [command]",
 		Args: cobra.NoArgs,
 		RunE: SubcommandRequired,
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,6 +29,11 @@ func Get(factory DPDKClientFactory) *cobra.Command {
 		GetVni(factory, rendererOptions),
 		GetVersion(factory, rendererOptions),
 		GetInit(factory, rendererOptions),
+		// Aliases for list commands
+		GetLoadBalancerPrefix(factory, rendererOptions),
+		GetLoadBalancerTarget(factory, rendererOptions),
+		GetPrefix(factory, rendererOptions),
+		GetRoute(factory, rendererOptions),
 	}
 
 	cmd.Short = fmt.Sprintf("Gets one of %v", CommandNames(subcommands))

--- a/cmd/get_firewall_rule.go
+++ b/cmd/get_firewall_rule.go
@@ -24,6 +24,15 @@ func GetFirewallRule(dpdkClientFactory DPDKClientFactory, rendererFactory Render
 		Example: "dpservice-cli get fwrule --rule-id=1 --interface-id=vm1",
 		Aliases: FirewallRuleAliases,
 		Args:    cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			filter, _ := cmd.Flags().GetString("rule-id")
+			if filter != "" {
+				if err := cmd.MarkFlagRequired("interface-id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			return RunGetFirewallRule(
@@ -53,11 +62,6 @@ func (o *GetFirewallRuleOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *GetFirewallRuleOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"interface-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/cmd/get_firewall_rule.go
+++ b/cmd/get_firewall_rule.go
@@ -53,7 +53,7 @@ func (o *GetFirewallRuleOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *GetFirewallRuleOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"rule-id", "interface-id"} {
+	for _, name := range []string{"interface-id"} {
 		if err := cmd.MarkFlagRequired(name); err != nil {
 			return err
 		}
@@ -73,10 +73,19 @@ func RunGetFirewallRule(
 	}
 	defer DpdkClose(cleanup)
 
-	fwrule, err := client.GetFirewallRule(ctx, opts.InterfaceID, opts.RuleID)
-	if err != nil && fwrule.Status.Code == 0 {
-		return fmt.Errorf("error getting firewall rule: %w", err)
-	}
+	if opts.RuleID == "" {
+		return RunListFirewallRules(
+			ctx,
+			dpdkClientFactory,
+			rendererFactory,
+			ListFirewallRulesOptions{InterfaceID: opts.InterfaceID},
+		)
+	} else {
+		fwrule, err := client.GetFirewallRule(ctx, opts.InterfaceID, opts.RuleID)
+		if err != nil && fwrule.Status.Code == 0 {
+			return fmt.Errorf("error getting firewall rule: %w", err)
+		}
 
-	return rendererFactory.RenderObject("", os.Stdout, fwrule)
+		return rendererFactory.RenderObject("", os.Stdout, fwrule)
+	}
 }

--- a/cmd/get_loadbalancer_prefix.go
+++ b/cmd/get_loadbalancer_prefix.go
@@ -1,16 +1,5 @@
-// Copyright 2022 IronCore authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/cmd/get_loadbalancer_prefix.go
+++ b/cmd/get_loadbalancer_prefix.go
@@ -1,0 +1,49 @@
+// Copyright 2022 IronCore authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/spf13/cobra"
+)
+
+func GetLoadBalancerPrefix(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFactory) *cobra.Command {
+	var (
+		opts ListLoadBalancerPrefixesOptions
+	)
+
+	cmd := &cobra.Command{
+		Use:     "lbprefix <--interface-id>",
+		Short:   "List loadbalancer prefixes on interface.",
+		Example: "dpservice-cli get lbprefix --interface-id=vm1",
+		Aliases: LoadBalancerPrefixAliases,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			return RunListLoadBalancerPrefixes(
+				cmd.Context(),
+				dpdkClientFactory,
+				rendererFactory,
+				opts,
+			)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	util.Must(opts.MarkRequiredFlags(cmd))
+
+	return cmd
+}

--- a/cmd/get_loadbalancer_target.go
+++ b/cmd/get_loadbalancer_target.go
@@ -1,16 +1,5 @@
-// Copyright 2022 IronCore authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/cmd/get_loadbalancer_target.go
+++ b/cmd/get_loadbalancer_target.go
@@ -1,0 +1,49 @@
+// Copyright 2022 IronCore authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/spf13/cobra"
+)
+
+func GetLoadBalancerTarget(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFactory) *cobra.Command {
+	var (
+		opts ListLoadBalancerTargetOptions
+	)
+
+	cmd := &cobra.Command{
+		Use:     "lbtarget <--lb-id>",
+		Short:   "List LoadBalancer Targets",
+		Example: "dpservice-cli get lbtarget --lb-id=1",
+		Aliases: LoadBalancerTargetAliases,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			return RunListLoadBalancerTargets(
+				cmd.Context(),
+				dpdkClientFactory,
+				rendererFactory,
+				opts,
+			)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	util.Must(opts.MarkRequiredFlags(cmd))
+
+	return cmd
+}

--- a/cmd/get_nat.go
+++ b/cmd/get_nat.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/ironcore-dev/dpservice-go/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -51,11 +52,6 @@ func (o *GetNatOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *GetNatOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"interface-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -70,6 +66,25 @@ func RunGetNat(
 		return fmt.Errorf("error creating dpdk client: %w", err)
 	}
 	defer DpdkClose(cleanup)
+
+	if opts.InterfaceID == "" {
+		ifaces, err := client.ListInterfaces(ctx)
+		if err != nil && ifaces.Status.Code == 0 {
+			return fmt.Errorf("error listing interfaces: %w", err)
+		}
+		natList := api.NatList{
+			TypeMeta: api.TypeMeta{Kind: api.NatListKind},
+		}
+		for _, iface := range ifaces.Items {
+			nat, err := client.GetNat(ctx, iface.ID)
+			if err != nil && nat.Status.Code == 0 {
+				return fmt.Errorf("error getting nat: %w", err)
+			}
+			natList.Items = append(natList.Items, *nat)
+		}
+
+		return rendererFactory.RenderList("", os.Stdout, &natList)
+	}
 
 	nat, err := client.GetNat(ctx, opts.InterfaceID)
 	if err != nil && nat.Status.Code == 0 {

--- a/cmd/get_prefix.go
+++ b/cmd/get_prefix.go
@@ -1,16 +1,5 @@
-// Copyright 2022 IronCore authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/cmd/get_prefix.go
+++ b/cmd/get_prefix.go
@@ -1,0 +1,48 @@
+// Copyright 2022 IronCore authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/spf13/cobra"
+)
+
+func GetPrefix(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFactory) *cobra.Command {
+	var (
+		opts ListPrefixesOptions
+	)
+
+	cmd := &cobra.Command{
+		Use:     "prefix <--interface-id>",
+		Short:   "List prefix(es) on interface.",
+		Example: "dpservice-cli get prefix --interface-id=vm1",
+		Args:    cobra.ExactArgs(0),
+		Aliases: PrefixAliases,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunListPrefixes(
+				cmd.Context(),
+				dpdkClientFactory,
+				rendererFactory,
+				opts,
+			)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	util.Must(opts.MarkRequiredFlags(cmd))
+
+	return cmd
+}

--- a/cmd/get_route.go
+++ b/cmd/get_route.go
@@ -1,16 +1,5 @@
-// Copyright 2022 IronCore authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package cmd
 

--- a/cmd/get_route.go
+++ b/cmd/get_route.go
@@ -1,0 +1,49 @@
+// Copyright 2022 IronCore authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/spf13/cobra"
+)
+
+func GetRoute(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFactory) *cobra.Command {
+	var (
+		opts ListRoutesOptions
+	)
+
+	cmd := &cobra.Command{
+		Use:     "route <--vni>",
+		Short:   "List routes of specified VNI",
+		Example: "dpservice-cli get route --vni=100",
+		Aliases: RouteAliases,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			return RunGetRoute(
+				cmd.Context(),
+				dpdkClientFactory,
+				rendererFactory,
+				opts,
+			)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+
+	util.Must(opts.MarkRequiredFlags(cmd))
+
+	return cmd
+}

--- a/cmd/get_virtualip.go
+++ b/cmd/get_virtualip.go
@@ -9,6 +9,8 @@ import (
 	"os"
 
 	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/ironcore-dev/dpservice-go/api"
+	"github.com/ironcore-dev/dpservice-go/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -51,11 +53,6 @@ func (o *GetVirtualIPOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *GetVirtualIPOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"interface-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -70,6 +67,42 @@ func RunGetVirtualIP(
 		return fmt.Errorf("error creating dpdk client: %w", err)
 	}
 	defer DpdkClose(cleanup)
+
+	if opts.InterfaceID == "" {
+		ifaces, err := client.ListInterfaces(ctx)
+		if err != nil && ifaces.Status.Code == 0 {
+			return fmt.Errorf("error listing interfaces: %w", err)
+		}
+		virtualIPs := make([]*api.VirtualIP, 0, len(ifaces.Items))
+		for _, iface := range ifaces.Items {
+			vip, err := client.GetVirtualIP(ctx, iface.ID, errors.Ignore(errors.SNAT_NO_DATA))
+			if err != nil && vip.Status.Code == 0 {
+				return fmt.Errorf("error getting virtual ip: %w", err)
+			}
+			if vip.Status.Code == 0 {
+				virtualIPs = append(virtualIPs, vip)
+			}
+		}
+		if len(virtualIPs) == 0 {
+			noVipFound := api.VirtualIP{
+				TypeMeta: api.TypeMeta{
+					Kind: api.VirtualIPKind,
+				},
+				Status: api.Status{
+					Code:    errors.SNAT_NO_DATA,
+					Message: "SNAT_NO_DATA",
+				},
+			}
+			return rendererFactory.RenderObject("no interface has virtual ip configured", os.Stdout, &noVipFound)
+		}
+		for _, vip := range virtualIPs {
+			err = rendererFactory.RenderObject("", os.Stdout, vip)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
 
 	virtualIP, err := client.GetVirtualIP(ctx, opts.InterfaceID)
 	if err != nil && virtualIP.Status.Code == 0 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -13,7 +13,7 @@ func List(factory DPDKClientFactory) *cobra.Command {
 	rendererOptions := &RendererOptions{Output: "table"}
 
 	cmd := &cobra.Command{
-		Use:  "list",
+		Use:  "list [command]",
 		Args: cobra.NoArgs,
 		RunE: SubcommandRequired,
 	}

--- a/cmd/list_firewall_rules.go
+++ b/cmd/list_firewall_rules.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/ironcore-dev/dpservice-go/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -54,11 +55,6 @@ func (o *ListFirewallRulesOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *ListFirewallRulesOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"interface-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -74,10 +70,29 @@ func RunListFirewallRules(
 	}
 	defer DpdkClose(cleanup)
 
-	fwruleList, err := client.ListFirewallRules(ctx, opts.InterfaceID)
-	if err != nil {
-		return fmt.Errorf("error listing firewall rules: %w", err)
+	fwruleList := &api.FirewallRuleList{
+		TypeMeta: api.TypeMeta{Kind: api.FirewallRuleListKind},
 	}
+	if opts.InterfaceID == "" {
+		ifaces, err := client.ListInterfaces(ctx)
+		if err != nil && ifaces.Status.Code == 0 {
+			return fmt.Errorf("error listing interfaces: %w", err)
+		}
+
+		for _, iface := range ifaces.Items {
+			fwrule, err := client.ListFirewallRules(ctx, iface.ID)
+			if err != nil && fwrule.Status.Code == 0 {
+				return fmt.Errorf("error getting firewall rules: %w", err)
+			}
+			fwruleList.Items = append(fwruleList.Items, fwrule.Items...)
+		}
+	} else {
+		fwruleList, err = client.ListFirewallRules(ctx, opts.InterfaceID)
+		if err != nil {
+			return fmt.Errorf("error listing firewall rules: %w", err)
+		}
+	}
+
 	// sort items in list
 	fwrules := fwruleList.Items
 	sort.SliceStable(fwrules, func(i, j int) bool {

--- a/cmd/list_nats.go
+++ b/cmd/list_nats.go
@@ -26,6 +26,7 @@ func ListNats(dpdkClientFactory DPDKClientFactory, rendererFactory RendererFacto
 		Use:     "nats <--nat-ip> <--nat-type>",
 		Short:   "List local/neighbor/both nats with selected IP",
 		Example: "dpservice-cli list nats --nat-ip=10.20.30.40 --info-type=local",
+		Aliases: NatAliases,
 		Args:    cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 

--- a/cmd/list_prefixes.go
+++ b/cmd/list_prefixes.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/ironcore-dev/dpservice-cli/util"
+	"github.com/ironcore-dev/dpservice-go/api"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -54,11 +55,6 @@ func (o *ListPrefixesOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *ListPrefixesOptions) MarkRequiredFlags(cmd *cobra.Command) error {
-	for _, name := range []string{"interface-id"} {
-		if err := cmd.MarkFlagRequired(name); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 
@@ -74,11 +70,28 @@ func RunListPrefixes(
 	}
 	defer DpdkClose(cleanup)
 
-	prefixList, err := client.ListPrefixes(ctx, opts.InterfaceID)
-	if err != nil {
-		return fmt.Errorf("error listing prefixes: %w", err)
+	prefixList := &api.PrefixList{
+		TypeMeta: api.TypeMeta{Kind: api.PrefixListKind},
 	}
+	if opts.InterfaceID == "" {
+		ifaces, err := client.ListInterfaces(ctx)
+		if err != nil && ifaces.Status.Code == 0 {
+			return fmt.Errorf("error listing interfaces: %w", err)
+		}
 
+		for _, iface := range ifaces.Items {
+			prefix, err := client.ListPrefixes(ctx, iface.ID)
+			if err != nil && prefix.Status.Code == 0 {
+				return fmt.Errorf("error getting prefixes: %w", err)
+			}
+			prefixList.Items = append(prefixList.Items, prefix.Items...)
+		}
+	} else {
+		prefixList, err = client.ListPrefixes(ctx, opts.InterfaceID)
+		if err != nil {
+			return fmt.Errorf("error listing prefixes: %w", err)
+		}
+	}
 	// sort items in list
 	prefixes := prefixList.Items
 	sort.SliceStable(prefixes, func(i, j int) bool {

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -13,7 +13,7 @@ func Reset(factory DPDKClientFactory) *cobra.Command {
 	rendererOptions := &RendererOptions{Output: "name"}
 
 	cmd := &cobra.Command{
-		Use:  "reset",
+		Use:  "reset [command]",
 		Args: cobra.NoArgs,
 		RunE: SubcommandRequired,
 	}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -264,7 +264,7 @@ func (t defaultTableConverter) interfaceTable(ifaces []api.Interface) (*TableDat
 	for i, iface := range ifaces {
 		columns[i] = []any{iface.ID, iface.Spec.VNI, iface.Spec.Device, iface.Spec.IPv4, iface.Spec.IPv6, iface.Spec.UnderlayRoute}
 		if iface.Spec.VirtualFunction != nil {
-			columns[i] = append(columns[i], iface.Spec.VirtualFunction.String())
+			columns[i] = append(columns[i], iface.Spec.VirtualFunction.Name)
 		} else if vfNeeded {
 			columns[i] = append(columns[i], "")
 		}


### PR DESCRIPTION
- Create get aliases for following list functions (eg. `get route` now equals `list routes`):

```
listLoadbalancerPrefixes > (list lbprefixes = get lbprefix)
listLoadbalancerTargets > (list lbtargets = get lbtarget)
listPrefixes > (list prefixes = get prefix)
listRoutes > (list routes = get route)
```

- Following commands now don’t require additional parameters/flags (without parameter, they will list all available objects of their type):

```
get firewallrule
get virtualip
get nat
get interface
list lbprefixes
list prefixes
```

- `List` and `get` commands now support singular/plural aliases interchangeably (eg. `get routes, list prefix`)

Closes #26